### PR TITLE
Write APPTYPE to package.conf

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -19,7 +19,6 @@ pub struct Build {
 
 impl Build {
     pub(crate) fn invoke(self, invocation: Invocation) {
-        let package_dot_conf = invocation.package_dot_conf();
         let acap_target = invocation.acap_target();
         let version = invocation.package_version();
         let global_options = invocation.global_options();
@@ -32,8 +31,8 @@ impl Build {
         };
 
         println!(
-            "cargo-acap: building ACAP package `{}` using Docker image {}",
-            &package_dot_conf.app_name, &global_options.docker_image
+            "cargo-acap: using Docker image {}",
+            &global_options.docker_image
         );
 
         if self.show_version || global_options.verbose > 0 {
@@ -47,6 +46,8 @@ impl Build {
         }
 
         for target in targets {
+            let package_dot_conf =
+                PackageDotConf::from_cargo_package(&invocation.cargo_package, target);
             BuildOp {
                 invocation: &invocation,
                 package_conf: &package_dot_conf,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,3 @@
-use crate::package_dot_conf::PackageDotConf;
 use crate::whoami::whoami;
 use clap::Parser;
 use std::ffi::OsString;
@@ -212,10 +211,6 @@ impl Invocation {
 
         docker.arg(&self.global_options.docker_image);
         docker
-    }
-
-    pub(crate) fn package_dot_conf(&self) -> PackageDotConf {
-        self.cargo_package.clone().into()
     }
 
     pub fn run_to_completion(&self, mut command: std::process::Command) {

--- a/src/package_dot_conf.rs
+++ b/src/package_dot_conf.rs
@@ -1,5 +1,6 @@
 use crate::cargo_config::CargoAcapMetadata;
 use crate::shell_includes;
+use crate::target::Target;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::fmt;
@@ -20,6 +21,10 @@ pub(crate) struct PackageDotConf {
 
     #[serde(rename = "VENDOR")]
     pub vendor: String,
+
+    /// The CPU architecture the app is built for
+    #[serde(rename = "APPTYPE")]
+    pub app_type: String,
 
     #[serde(rename = "APPOPTS")]
     pub launch_arguments: Option<String>,
@@ -116,8 +121,8 @@ pub enum StartMode {
     Never,
 }
 
-impl From<cargo::core::Package> for PackageDotConf {
-    fn from(package: cargo::core::Package) -> Self {
+impl PackageDotConf {
+    pub fn from_cargo_package(package: &cargo::core::Package, target: Target) -> Self {
         let acap_metadata_toml = package
             .manifest()
             .custom_metadata()
@@ -195,6 +200,7 @@ impl From<cargo::core::Package> for PackageDotConf {
             display_name,
             menu_name,
             axis_application_id: axis_application_id.unwrap_or_default(),
+            app_type: target.name().to_string(),
             vendor,
             launch_arguments,
             app_major_version,


### PR DESCRIPTION
Removes warning "acap apptype validation skipped (apptype value unset)" from syslog upon installation.