### PR TITLE
RFC: Add --no-docker option

### DIFF
--- a/.github/workflows/build-rust-image.yml
+++ b/.github/workflows/build-rust-image.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           fetch-depth: 2
       -
+        name: Build cargo-acap
+        run: cargo install --path . --root cargo-acap-build
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+/cargo-acap-build/.crates.toml
+/cargo-acap-build/.crates2.json
+/cargo-acap-build/bin/
 target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["axis", "acap"]
 
 [dependencies]
 cargo = "0.62"
-clap = { version = "3.2", features = ["derive", "suggestions"] }
+clap = { version = "3.2", features = ["derive", "env", "suggestions"] }
 deflate = { version = "1.0", features = ["gzip"] }
 rand = "0.8"
 semver = { version = "1.0", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -4,30 +4,7 @@ A tool to build Rust programs for the [AXIS Camera Application Platform](https:/
 
 ## Containerized builds
 
-```sh
-cargo build
-docker run \
-  --interactive \
-  --rm \
-  --tty \
-  --user $(id -u):$(id -g) \
-  --volume $(pwd):$(pwd) \
-  --volume ~/.cargo:/.cargo \
-  --workdir $(pwd) \
-  trunnion/cargo-acap:1.74.0 \
-  ./target/debug/cargo-acap \
-    --manifest-path `pwd`/app/acap-rust-http-example/Cargo.toml \
-    --no-docker \
-    build --target aarch64
-```
-
-```shell
-cargo run -- \
---docker-image trunnion/cargo-acap:1.74.0 \
---manifest-path `pwd`/app/acap-rust-http-example/Cargo.toml \
-build --target aarch64
-
-```
+To avoid docker-in-docker situations `cargo-acap` can be configured to run `cargo` without docker by setting `CARGO_ACAP_NO_DOCKER=1`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 A tool to build Rust programs for the [AXIS Camera Application Platform](https://www.axis.com/en-us/products/analytics/acap).
 
+## Containerized builds
+
+```sh
+cargo build
+docker run \
+  --interactive \
+  --rm \
+  --tty \
+  --user $(id -u):$(id -g) \
+  --volume $(pwd):$(pwd) \
+  --volume ~/.cargo:/.cargo \
+  --workdir $(pwd) \
+  trunnion/cargo-acap:1.74.0 \
+  ./target/debug/cargo-acap \
+    --manifest-path `pwd`/app/acap-rust-http-example/Cargo.toml \
+    --no-docker \
+    build --target aarch64
+```
+
+```shell
+cargo run -- \
+--docker-image trunnion/cargo-acap:1.74.0 \
+--manifest-path `pwd`/app/acap-rust-http-example/Cargo.toml \
+build --target aarch64
+
+```
+
 ## Example
 
 ```console

--- a/cargo-acap-build/Dockerfile
+++ b/cargo-acap-build/Dockerfile
@@ -100,3 +100,6 @@ ENV \
 # This problem should go away when the rust RFC lands and when the ecosystem has adopted its use.
   CARGO_TARGET_ARMV5TE_AXIS_LINUX_GNUEABI_RUSTFLAGS="--cfg crossbeam_no_atomic_64" \
   CARGO_TARGET_MIPSEL_AXIS_LINUX_GNU_RUSTFLAGS="--cfg crossbeam_no_atomic_64"
+
+COPY bin/cargo-acap /usr/local/bin/cargo-acap
+ENV CARGO_ACAP_NO_DOCKER=1

--- a/cargo-acap-build/README.md
+++ b/cargo-acap-build/README.md
@@ -26,6 +26,9 @@ This folder contains a `Dockerfile`, a `rust-config.toml` for the Rust build, an
 [the `rustc-dev` docs](https://rustc-dev-guide.rust-lang.org/building/prerequisites.html#hardware) for more specific
 guidance.
 
+The user is expected to add also `bin/cargo-acap` before building the image, e.g. like
+`cargo install --path . --root cargo-acap-build`.
+
 ### GitHub Actions
 
 `.github/workflows/` contains two associated GitHub Actions definitions:

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -41,8 +41,8 @@ impl Build {
             docker.args(&["images", &global_options.docker_image]);
             invocation.run_to_completion(docker);
 
-            let mut docker = invocation.docker_run_command();
-            docker.args(&["rustc", "version"]);
+            let mut docker = invocation.command("rustc");
+            docker.args(&[ "version"]);
             invocation.run_to_completion(docker);
         }
 
@@ -87,9 +87,8 @@ impl<'a> BuildOp<'a> {
     }
 
     fn cargo_build_in_docker(&self) -> PathBuf {
-        let mut docker = self.invocation.docker_run_command();
+        let mut docker = self.invocation.command("cargo");
         docker.args(&[
-            "cargo",
             "build",
             "--target",
             self.target.rust_target_triple(),
@@ -142,8 +141,8 @@ impl<'a> BuildOp<'a> {
     fn strip_executable(&self, built_executable_path: &Path) -> PathBuf {
         let stripped_executable_path = built_executable_path.with_extension("stripped");
 
-        let mut docker = self.invocation.docker_run_command();
-        docker.args(&[self.target.docker_objcopy_command(), "--strip-all"]);
+        let mut docker = self.invocation.command(self.target.docker_objcopy_command());
+        docker.args(&["--strip-all"]);
         docker.arg(&built_executable_path);
         docker.arg(&stripped_executable_path);
 


### PR DESCRIPTION
This is helpful if we want to build apps in Jenkins where it is convenient to install `cargo-acap` in a docker image and inconvenient to set up docker-in-docker.

Does that make sense?

If so I will clean up the PR.