### PR TITLE
Include optional files in "application organization"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ requires [Docker](https://docs.docker.com/get-docker/) to be installed and runni
 ```text
 foo/
     Cargo.toml                      Rust project configuration + `[package.metadata.acap]`
-    data/                           Copied to `/usr/local/packages/foo/data/`, i.e. `./data/`
+    cgi.txt                         Optional. If present, HTTPCGIPATHS is set to match.
+    postinstall.sh                  Optional POSTINSTALLSCRIPT is alwasy set to match.
+    otherfiles/                     Other static files to include.
     src/
         main.rs                     `fn main()`
     target/


### PR DESCRIPTION
This makes it easier to get an overview of the functions of the tool without reading its source code.

As far as I can tell the `data/` directory is never copied, but `otherfiles/` is.

Then there are two files named explicitly that when present in the manifest dir will be included in the `.eap`.